### PR TITLE
Minor javadoc changes and renames

### DIFF
--- a/src/test/java/io/pivotal/literx/Part01CreateFlux.java
+++ b/src/test/java/io/pivotal/literx/Part01CreateFlux.java
@@ -8,8 +8,8 @@ import reactor.core.test.TestSubscriber;
  * Learn how to create Flux instances.
  *
  * @author Sebastien Deleuze
- * @see <a href="http://projectreactor.io/core/docs/api/reactor/core/publisher/Flux.html>Flux Javadoc</a>
- * @see <a href="http://projectreactor.io/core/docs/api/reactor/core/test/TestSubscriber.html>TestSubscriber Javadoc</a>
+ * @see <a href="http://projectreactor.io/core/docs/api/reactor/core/publisher/Flux.html">Flux Javadoc</a>
+ * @see <a href="http://projectreactor.io/core/docs/api/reactor/core/test/TestSubscriber.html">TestSubscriber Javadoc</a>
  */
 public class Part01CreateFlux {
 

--- a/src/test/java/io/pivotal/literx/Part02CreateMono.java
+++ b/src/test/java/io/pivotal/literx/Part02CreateMono.java
@@ -8,8 +8,8 @@ import reactor.core.test.TestSubscriber;
  * Learn how to create Mono instances.
  *
  * @author Sebastien Deleuze
- * @see <a href="http://projectreactor.io/core/docs/api/reactor/core/publisher/Mono.html>Mono Javadoc</a>
- * @see <a href="http://projectreactor.io/core/docs/api/reactor/core/test/TestSubscriber.html>TestSubscriber Javadoc</a>
+ * @see <a href="http://projectreactor.io/core/docs/api/reactor/core/publisher/Mono.html">Mono Javadoc</a>
+ * @see <a href="http://projectreactor.io/core/docs/api/reactor/core/test/TestSubscriber.html">TestSubscriber Javadoc</a>
  */
 public class Part02CreateMono {
 

--- a/src/test/java/io/pivotal/literx/Part09BlockingToReactive.java
+++ b/src/test/java/io/pivotal/literx/Part09BlockingToReactive.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertFalse;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.publisher.SchedulerGroup;
+import reactor.core.publisher.Computations;
 import reactor.core.test.TestSubscriber;
 
 /**
@@ -27,7 +27,7 @@ import reactor.core.test.TestSubscriber;
  * @author Sebastien Deleuze
  * @see Flux#publishOn(Callable)
  * @see Flux#dispatchOn(Callable)
- * @see SchedulerGroup
+ * @see Computations
  */
 public class Part09BlockingToReactive {
 


### PR DESCRIPTION
A couple of minor things I noticed whilst going through it. doc links missing closing quotes and the code didn't reflect the name change to Computations from SchedulerGroup. 
