### PR TITLE
Add call counter to blocking repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@
 target/
 *.iml
 .idea/
-
+.classpath
+.project
+.settings/

--- a/src/test/java/io/pivotal/literx/repository/BlockingUserRepository.java
+++ b/src/test/java/io/pivotal/literx/repository/BlockingUserRepository.java
@@ -7,6 +7,7 @@ public class BlockingUserRepository implements BlockingRepository<User>{
 
 	private final ReactiveRepository<User> reactiveRepository;
 
+	private int callCount = 0;
 
 	public BlockingUserRepository() {
 		reactiveRepository = new ReactiveUserRepository();
@@ -27,21 +28,29 @@ public class BlockingUserRepository implements BlockingRepository<User>{
 
 	@Override
 	public void save(User user) {
+		callCount++;
 		reactiveRepository.save(Mono.just(user)).get();
 	}
 
 	@Override
 	public User findFirst() {
+		callCount++;
 		return reactiveRepository.findFirst().get();
 	}
 
 	@Override
 	public Iterable<User> findAll() {
+		callCount++;
 		return reactiveRepository.findAll().toIterable();
 	}
 
 	@Override
 	public User findById(String username) {
+		callCount++;
 		return reactiveRepository.findById(username).get();
+	}
+	
+	public int getCallCount() {
+		return callCount;
 	}
 }


### PR DESCRIPTION
Without the counter (or something like it) you can't assert that
the repositroy wasn't called on the main thread. In fact it was
being called on the main thread, so this change also uses
Flux.defer() to push the call onto the subscriber thread.
