### PR TITLE
Simplified creation of Observalble and Single instances

### DIFF
--- a/src/test/java/io/pivotal/literx/Part09Adapt.java
+++ b/src/test/java/io/pivotal/literx/Part09Adapt.java
@@ -83,7 +83,7 @@ public class Part09Adapt {
 
 	// TODO Adapt Flux to RxJava Observable
 	Observable<User> fromFluxToObservable(Flux<User> flux) {
-		return Flowable.fromPublisher(flux).toObservable(); // TO BE REMOVED
+		return Observable.fromPublisher(flux); // TO BE REMOVED
 	}
 
 	// TODO Adapt RxJava Observable to Flux
@@ -105,7 +105,7 @@ public class Part09Adapt {
 
 	// TODO Adapt Mono to RxJava Single
 	Single<User> fromMonoToSingle(Mono<User> mono) {
-		return Flowable.fromPublisher(mono).toObservable().firstOrError(); // TO BE REMOVED
+		return Single.fromPublisher(mono); // TO BE REMOVED
 	}
 
 	// TODO Adapt RxJava Single to Mono


### PR DESCRIPTION
Hi,
I think in the completed version of excercise 9 methods `fromFluxToObservable` and `fromMonoToSingle` can be implemented in a simpler way using existing API method `fromPublisher`. 