### PR TITLE
Bump the "complete" branch to latest reactor 3.1.0.M1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,28 +20,25 @@
 
 	<groupId>io.pivotal</groupId>
 	<artifactId>lite-rx-api-hands-on</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>A lite Rx API for the JVM Hands-on</name>
-	<description>Lite Rx API Hands-On based on Reactor Core 3.0</description>
+	<description>Lite Rx API Hands-On based on Reactor Core 3.1</description>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
-		<reactore.core.version>3.0.6.RELEASE</reactore.core.version>
 	</properties>
 
 	<dependencies>
 		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-core</artifactId>
-			<version>${reactore.core.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.projectreactor.addons</groupId>
 			<artifactId>reactor-test</artifactId>
-			<version>${reactore.core.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
@@ -85,5 +82,26 @@
 			</plugin>
 		</plugins>
 	</build>
-	
+
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>io.projectreactor</groupId>
+				<artifactId>reactor-bom</artifactId>
+				<version>Bismuth-M1</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<repositories>
+		<repository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones Repository</name>
+			<url>https://repo.spring.io/milestone</url>
+		</repository>
+	</repositories>
+
 </project>

--- a/src/test/java/io/pivotal/literx/Part07Errors.java
+++ b/src/test/java/io/pivotal/literx/Part07Errors.java
@@ -52,7 +52,7 @@ public class Part07Errors {
 
 	// TODO Return a Mono<User> containing User.SAUL when an error occurs in the input Mono, else do not change the input Mono.
 	Mono<User> betterCallSaulForBogusMono(Mono<User> mono) {
-		return mono.otherwise(e -> Mono.just(User.SAUL)); // TO BE REMOVED
+		return mono.onErrorResume(e -> Mono.just(User.SAUL)); // TO BE REMOVED
 	}
 
 //========================================================================================
@@ -72,7 +72,7 @@ public class Part07Errors {
 
 	// TODO Return a Flux<User> containing User.SAUL and User.JESSE when an error occurs in the input Flux, else do not change the input Flux.
 	Flux<User> betterCallSaulAndJesseForBogusFlux(Flux<User> flux) {
-		return flux.onErrorResumeWith(e -> Flux.just(User.SAUL, User.JESSE)); // TO BE REMOVED
+		return flux.onErrorResume(e -> Flux.just(User.SAUL, User.JESSE)); // TO BE REMOVED
 	}
 
 //========================================================================================

--- a/src/test/java/io/pivotal/literx/repository/ReactiveUserRepository.java
+++ b/src/test/java/io/pivotal/literx/repository/ReactiveUserRepository.java
@@ -65,7 +65,7 @@ public class ReactiveUserRepository implements ReactiveRepository<User> {
 	private Mono<User> withDelay(Mono<User> userMono) {
 		return Mono
 				.delay(Duration.ofMillis(delayInMs))
-				.then(c -> userMono);
+				.flatMap(c -> userMono);
 	}
 
 	private Flux<User> withDelay(Flux<User> userFlux) {


### PR DESCRIPTION
Most notably:
  - `Mono.otherwise` has been renamed to `onErrorResume`
  - `Mono.then(Function)` has been renamed to `flatMap`
  - `Flux.onErrorResumeWith` has been renamed to `onErrorResume`
  - note the old `Mono.flatMap` which returns a `Flux` is now named
  `flatMapMany`