### PR TITLE
Fix typo in techio lesson on StepVerifier

### DIFF
--- a/techio/part03StepVerifier.md
+++ b/techio/part03StepVerifier.md
@@ -72,11 +72,12 @@ so you should usually put a `expectSubscription()` after `.withVirtualTime()` if
 going to use `expectNoEvent` right after).
 
 ```Java
-StepVerifier.withVirtualtime(() -> Mono.delay(Duration.ofHours(3)))
+StepVerifier.withVirtualTime(() -> Mono.delay(Duration.ofHours(3)))
             .expectSubscription()
             .expectNoEvent(Duration.ofHours(2))
             .thenAwait(Duration.ofHours(1))
             .expectNextCount(1)
+            .expectComplete()
             .verify();
 ```
 


### PR DESCRIPTION
Hi,
I found a little inconsistencies 
in the ["StepVerifier and how to use it"](https://tech.io/playgrounds/929/reactive-programming-with-reactor-3/StepVerifier) part 
of the "Reactive Programming with Reactor 3 tutorial" . 
If they was unintentional 
here is my proposal of improving it . 