### PR TITLE
Add serialVersionUID to GetOutOfHereException

### DIFF
--- a/src/main/java/io/pivotal/literx/Part07Errors.java
+++ b/src/main/java/io/pivotal/literx/Part07Errors.java
@@ -59,6 +59,7 @@ public class Part07Errors {
 	}
 
 	protected final class GetOutOfHereException extends Exception {
+	    private static final long serialVersionUID = 0L;
 	}
 
 }


### PR DESCRIPTION
Without it, you get a confusing warning when following the tutorial when your code is right. Addressing this [issue](https://github.com/reactor/lite-rx-api-hands-on/issues/53)