### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ This Hands-on is designed to help you to learn easily the lite Rx API provided b
 
 You will mostly need these 3 classes Javadoc:
 
- - [Flux](http://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html)
- - [Mono](http://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html)
- - [StepVerifier](http://projectreactor.io/docs/test/release/api/reactor/test/StepVerifier.html)
+ - [Flux](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html)
+ - [Mono](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html)
+ - [StepVerifier](https://projectreactor.io/docs/test/release/api/reactor/test/StepVerifier.html)
  
 To do this Hands-on, you just have to:
 
- - Have [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) and a Java IDE ([IntelliJ IDEA](https://www.jetbrains.com/idea/) for example) installed with Maven support
+ - Have [Java 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) and a Java IDE ([IntelliJ IDEA](https://www.jetbrains.com/idea/) for example) installed with Maven support
  - Clone this repository (or your fork)
  - Import the project as a Maven one in your IDE
  - Make sure that the language level is set to Java 8 in your IDE project settings
@@ -21,4 +21,4 @@ The solution is available in the `solution` branch to compare, when you have fin
 
 A Kotlin version that takes advantage of [reactor-kotlin-extensions](https://github.com/reactor/reactor-kotlin-extensions) is available [here](https://github.com/eddumelendez/reactor-kotlin-workshop).
  
-More information available on [Reactor website](http://projectreactor.io).
+More information available on [Reactor website](https://projectreactor.io).

--- a/src/main/java/io/pivotal/literx/Part01Flux.java
+++ b/src/main/java/io/pivotal/literx/Part01Flux.java
@@ -6,7 +6,7 @@ import reactor.core.publisher.Flux;
  * Learn how to create Flux instances.
  *
  * @author Sebastien Deleuze
- * @see <a href="http://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html">Flux Javadoc</a>
+ * @see <a href="https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html">Flux Javadoc</a>
  */
 public class Part01Flux {
 

--- a/src/main/java/io/pivotal/literx/Part02Mono.java
+++ b/src/main/java/io/pivotal/literx/Part02Mono.java
@@ -6,7 +6,7 @@ import reactor.core.publisher.Mono;
  * Learn how to create Mono instances.
  *
  * @author Sebastien Deleuze
- * @see <a href="http://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html">Mono Javadoc</a>
+ * @see <a href="https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html">Mono Javadoc</a>
  */
 public class Part02Mono {
 

--- a/src/main/java/io/pivotal/literx/Part03StepVerifier.java
+++ b/src/main/java/io/pivotal/literx/Part03StepVerifier.java
@@ -25,7 +25,7 @@ import reactor.core.publisher.Flux;
  * Learn how to use StepVerifier to test Mono, Flux or any other kind of Reactive Streams Publisher.
  *
  * @author Sebastien Deleuze
- * @see <a href="http://projectreactor.io/docs/test/release/api/reactor/test/StepVerifier.html">StepVerifier Javadoc</a>
+ * @see <a href="https://projectreactor.io/docs/test/release/api/reactor/test/StepVerifier.html">StepVerifier Javadoc</a>
  */
 public class Part03StepVerifier {
 

--- a/src/test/java/io/pivotal/literx/Part01FluxTest.java
+++ b/src/test/java/io/pivotal/literx/Part01FluxTest.java
@@ -8,7 +8,7 @@ import reactor.test.StepVerifier;
  * Learn how to create Flux instances.
  *
  * @author Sebastien Deleuze
- * @see <a href="http://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html">Flux Javadoc</a>
+ * @see <a href="https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html">Flux Javadoc</a>
  */
 public class Part01FluxTest {
 

--- a/src/test/java/io/pivotal/literx/Part02MonoTest.java
+++ b/src/test/java/io/pivotal/literx/Part02MonoTest.java
@@ -10,7 +10,7 @@ import reactor.test.StepVerifier;
  * Learn how to create Mono instances.
  *
  * @author Sebastien Deleuze
- * @see <a href="http://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html">Mono Javadoc</a>
+ * @see <a href="https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html">Mono Javadoc</a>
  */
 public class Part02MonoTest {
 

--- a/src/test/java/io/pivotal/literx/Part03StepVerifierTest.java
+++ b/src/test/java/io/pivotal/literx/Part03StepVerifierTest.java
@@ -27,7 +27,7 @@ import reactor.core.publisher.Mono;
  * Learn how to use StepVerifier to test Mono, Flux or any other kind of Reactive Streams Publisher.
  *
  * @author Sebastien Deleuze
- * @see <a href="http://projectreactor.io/docs/test/release/api/reactor/test/StepVerifier.html">StepVerifier Javadoc</a>
+ * @see <a href="https://projectreactor.io/docs/test/release/api/reactor/test/StepVerifier.html">StepVerifier Javadoc</a>
  */
 public class Part03StepVerifierTest {
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://projectreactor.io with 1 occurrences migrated to:  
  https://projectreactor.io ([https](https://projectreactor.io) result 200).
* http://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html with 3 occurrences migrated to:  
  https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html ([https](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html) result 200).
* http://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html with 3 occurrences migrated to:  
  https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html ([https](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html) result 200).
* http://projectreactor.io/docs/test/release/api/reactor/test/StepVerifier.html with 3 occurrences migrated to:  
  https://projectreactor.io/docs/test/release/api/reactor/test/StepVerifier.html ([https](https://projectreactor.io/docs/test/release/api/reactor/test/StepVerifier.html) result 200).
* http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html with 1 occurrences migrated to:  
  https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html ([https](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) result 200).