### PR TITLE
URL Cleanup

### DIFF
--- a/src/main/java/io/pivotal/literx/Part01Flux.java
+++ b/src/main/java/io/pivotal/literx/Part01Flux.java
@@ -1,5 +1,8 @@
 package io.pivotal.literx;
 
+import java.time.Duration;
+import java.util.Arrays;
+
 import reactor.core.publisher.Flux;
 
 /**
@@ -14,35 +17,37 @@ public class Part01Flux {
 
 	// TODO Return an empty Flux
 	Flux<String> emptyFlux() {
-		return null;
+		return Flux.empty(); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Return a Flux that contains 2 values "foo" and "bar" without using an array or a collection
 	Flux<String> fooBarFluxFromValues() {
-		return null;
+		return Flux.just("foo", "bar"); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Create a Flux from a List that contains 2 values "foo" and "bar"
 	Flux<String> fooBarFluxFromList() {
-		return null;
+		return Flux.fromIterable(Arrays.asList("foo", "bar")); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Create a Flux that emits an IllegalStateException
 	Flux<String> errorFlux() {
-		return null;
+		return Flux.error(new IllegalStateException()); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 		// TODO Create a Flux that emits increasing values from 0 to 9 each 100ms
 	Flux<Long> counter() {
-		return null;
+		return Flux
+				.interval(Duration.ofMillis(100))
+				.take(10);  // TO BE REMOVED
 	}
 
 }

--- a/src/main/java/io/pivotal/literx/Part02Mono.java
+++ b/src/main/java/io/pivotal/literx/Part02Mono.java
@@ -14,28 +14,28 @@ public class Part02Mono {
 
 	// TODO Return an empty Mono
 	Mono<String> emptyMono() {
-		return null;
+		return Mono.empty(); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Return a Mono that never emits any signal
 	Mono<String> monoWithNoSignal() {
-		return null;
+		return Mono.never(); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Return a Mono that contains a "foo" value
 	Mono<String> fooMono() {
-		return null;
+		return Mono.just("foo"); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Create a Mono that emits an IllegalStateException
 	Mono<String> errorMono() {
-		return null;
+		return Mono.error(new IllegalStateException()); // TO BE REMOVED
 	}
 
 }

--- a/src/main/java/io/pivotal/literx/Part03StepVerifier.java
+++ b/src/main/java/io/pivotal/literx/Part03StepVerifier.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/pivotal/literx/Part03StepVerifier.java
+++ b/src/main/java/io/pivotal/literx/Part03StepVerifier.java
@@ -16,10 +16,13 @@
 
 package io.pivotal.literx;
 
+import java.time.Duration;
 import java.util.function.Supplier;
 
 import io.pivotal.literx.domain.User;
+import org.assertj.core.api.Assertions;
 import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
 
 /**
  * Learn how to use StepVerifier to test Mono, Flux or any other kind of Reactive Streams Publisher.
@@ -33,14 +36,18 @@ public class Part03StepVerifier {
 
 	// TODO Use StepVerifier to check that the flux parameter emits "foo" and "bar" elements then completes successfully.
 	void expectFooBarComplete(Flux<String> flux) {
-		fail();
+		StepVerifier.create(flux)
+				.expectNext("foo", "bar")
+				.verifyComplete(); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Use StepVerifier to check that the flux parameter emits "foo" and "bar" elements then a RuntimeException error.
 	void expectFooBarError(Flux<String> flux) {
-		fail();
+		StepVerifier.create(flux)
+				.expectNext("foo", "bar")
+				.verifyError(RuntimeException.class); // TO BE REMOVED
 	}
 
 //========================================================================================
@@ -48,14 +55,19 @@ public class Part03StepVerifier {
 	// TODO Use StepVerifier to check that the flux parameter emits a User with "swhite"username
 	// and another one with "jpinkman" then completes successfully.
 	void expectSkylerJesseComplete(Flux<User> flux) {
-		fail();
+		StepVerifier.create(flux)
+				.expectNextMatches(user -> user.getUsername().equals("swhite"))
+				.assertNext(user -> Assertions.assertThat(user.getUsername()).isEqualToIgnoringCase("jpinkman"))
+				.verifyComplete(); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Expect 10 elements then complete and notice how long the test takes.
 	void expect10Elements(Flux<Long> flux) {
-		fail();
+		StepVerifier.create(flux)
+                .expectNextCount(10)
+                .verifyComplete(); // TO BE REMOVED
 	}
 
 //========================================================================================
@@ -63,7 +75,10 @@ public class Part03StepVerifier {
 	// TODO Expect 3600 elements at intervals of 1 second, and verify quicker than 3600s
 	// by manipulating virtual time thanks to StepVerifier#withVirtualTime, notice how long the test takes
 	void expect3600Elements(Supplier<Flux<Long>> supplier) {
-		fail();
+		StepVerifier.withVirtualTime(supplier)
+		            .thenAwait(Duration.ofHours(1))
+		            .expectNextCount(3600)
+		            .verifyComplete(); // TO BE REMOVED
 	}
 
 	private void fail() {

--- a/src/main/java/io/pivotal/literx/Part04Transform.java
+++ b/src/main/java/io/pivotal/literx/Part04Transform.java
@@ -15,21 +15,24 @@ public class Part04Transform {
 
 	// TODO Capitalize the user username, firstname and lastname
 	Mono<User> capitalizeOne(Mono<User> mono) {
-		return null;
+		return mono.map(u -> new User(u.getUsername().toUpperCase(), u.getFirstname().toUpperCase(), u.getLastname().toUpperCase())); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Capitalize the users username, firstName and lastName
 	Flux<User> capitalizeMany(Flux<User> flux) {
-		return null;
+		return flux.map(u -> new User(
+				u.getUsername().toUpperCase(),
+				u.getFirstname().toUpperCase(),
+				u.getLastname().toUpperCase())); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Capitalize the users username, firstName and lastName using #asyncCapitalizeUser
 	Flux<User> asyncCapitalizeMany(Flux<User> flux) {
-		return null;
+		return flux.flatMap(u -> asyncCapitalizeUser(u)); // TO BE REMOVED
 	}
 
 	Mono<User> asyncCapitalizeUser(User u) {

--- a/src/main/java/io/pivotal/literx/Part05Merge.java
+++ b/src/main/java/io/pivotal/literx/Part05Merge.java
@@ -15,21 +15,21 @@ public class Part05Merge {
 
 	// TODO Merge flux1 and flux2 values with interleave
 	Flux<User> mergeFluxWithInterleave(Flux<User> flux1, Flux<User> flux2) {
-		return null;
+		return flux1.mergeWith(flux2); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Merge flux1 and flux2 values with no interleave (flux1 values and then flux2 values)
 	Flux<User> mergeFluxWithNoInterleave(Flux<User> flux1, Flux<User> flux2) {
-		return null;
+		return flux1.concatWith(flux2); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Create a Flux containing the value of mono1 then the value of mono2
 	Flux<User> createFluxFromMultipleMono(Mono<User> mono1, Mono<User> mono2) {
-		return null;
+		return Flux.concat(mono1, mono2);  // TO BE REMOVED
 	}
 
 }

--- a/src/main/java/io/pivotal/literx/Part06Request.java
+++ b/src/main/java/io/pivotal/literx/Part06Request.java
@@ -19,28 +19,40 @@ public class Part06Request {
 
 	// TODO Create a StepVerifier that initially requests all values and expect 4 values to be received
 	StepVerifier requestAllExpectFour(Flux<User> flux) {
-		return null;
+		return StepVerifier.create(flux)
+				.expectNextCount(4)
+				.expectComplete(); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Create a StepVerifier that initially requests 1 value and expects User.SKYLER then requests another value and expects User.JESSE.
 	StepVerifier requestOneExpectSkylerThenRequestOneExpectJesse(Flux<User> flux) {
-		return null;
+		return StepVerifier.create(flux, 1)
+				.expectNext(User.SKYLER)
+				.thenRequest(1)
+				.expectNext(User.JESSE)
+				.thenCancel(); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Return a Flux with all users stored in the repository that prints automatically logs for all Reactive Streams signals
 	Flux<User> fluxWithLog() {
-		return null;
+		return repository
+				.findAll()
+				.log(); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Return a Flux with all users stored in the repository that prints "Starring:" on subscribe, "firstname lastname" for all values and "The end!" on complete
 	Flux<User> fluxWithDoOnPrintln() {
-		return null;
+		return repository
+				.findAll()
+				.doOnSubscribe(s -> System.out.println("Starring:"))
+				.doOnNext(p -> System.out.println(p.getFirstname() + " " + p.getLastname()))
+				.doOnComplete(() -> System.out.println("The end!")); // TO BE REMOVED
 	}
 
 }

--- a/src/main/java/io/pivotal/literx/Part07Errors.java
+++ b/src/main/java/io/pivotal/literx/Part07Errors.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/pivotal/literx/Part07Errors.java
+++ b/src/main/java/io/pivotal/literx/Part07Errors.java
@@ -33,14 +33,14 @@ public class Part07Errors {
 
 	// TODO Return a Mono<User> containing User.SAUL when an error occurs in the input Mono, else do not change the input Mono.
 	Mono<User> betterCallSaulForBogusMono(Mono<User> mono) {
-		return null;
+		return mono.onErrorResume(e -> Mono.just(User.SAUL)); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Return a Flux<User> containing User.SAUL and User.JESSE when an error occurs in the input Flux, else do not change the input Flux.
 	Flux<User> betterCallSaulAndJesseForBogusFlux(Flux<User> flux) {
-		return null;
+		return flux.onErrorResume(e -> Flux.just(User.SAUL, User.JESSE)); // TO BE REMOVED
 	}
 
 //========================================================================================
@@ -48,7 +48,14 @@ public class Part07Errors {
 	// TODO Implement a method that capitalizes each user of the incoming flux using the
 	// #capitalizeUser method and emits an error containing a GetOutOfHereException error
 	Flux<User> capitalizeMany(Flux<User> flux) {
-		return null;
+		return flux.map(user -> {
+			try {
+				return capitalizeUser(user);
+			}
+			catch (GetOutOfHereException e) {
+				throw Exceptions.propagate(e);
+			}
+		}); // TO BE REMOVED
 	}
 
 	User capitalizeUser(User user) throws GetOutOfHereException {

--- a/src/main/java/io/pivotal/literx/Part08OtherOperations.java
+++ b/src/main/java/io/pivotal/literx/Part08OtherOperations.java
@@ -15,42 +15,44 @@ public class Part08OtherOperations {
 
 	// TODO Create a Flux of user from Flux of username, firstname and lastname.
 	Flux<User> userFluxFromStringFlux(Flux<String> usernameFlux, Flux<String> firstnameFlux, Flux<String> lastnameFlux) {
-		return null;
+		return Flux
+				.zip(usernameFlux, firstnameFlux, lastnameFlux)
+				.map(tuple -> new User(tuple.getT1(), tuple.getT2(), tuple.getT3())); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Return the mono which returns its value faster
 	Mono<User> useFastestMono(Mono<User> mono1, Mono<User> mono2) {
-		return null;
+		return Mono.first(mono1, mono2); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Return the flux which returns the first value faster
 	Flux<User> useFastestFlux(Flux<User> flux1, Flux<User> flux2) {
-		return null;
+		return Flux.first(flux1, flux2); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Convert the input Flux<User> to a Mono<Void> that represents the complete signal of the flux
 	Mono<Void> fluxCompletion(Flux<User> flux) {
-		return null;
+		return flux.then(); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Return a valid Mono of user for null input and non null input user (hint: Reactive Streams do not accept null values)
 	Mono<User> nullAwareUserToMono(User user) {
-		return null;
+		return Mono.justOrEmpty(user); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Return the same mono passed as input parameter, expect that it will emit User.SKYLER when empty
 	Mono<User> emptyToSkyler(Mono<User> mono) {
-		return null;
+		return mono.defaultIfEmpty(User.SKYLER); // TO BE REMOVED
 	}
 
 }

--- a/src/main/java/io/pivotal/literx/Part09Adapt.java
+++ b/src/main/java/io/pivotal/literx/Part09Adapt.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/pivotal/literx/Part09Adapt.java
+++ b/src/main/java/io/pivotal/literx/Part09Adapt.java
@@ -19,6 +19,7 @@ package io.pivotal.literx;
 import java.util.concurrent.CompletableFuture;
 
 import io.pivotal.literx.domain.User;
+import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
@@ -43,48 +44,48 @@ public class Part09Adapt {
 
 	// TODO Adapt Flux to RxJava Flowable
 	Flowable<User> fromFluxToFlowable(Flux<User> flux) {
-		return null;
+		return Flowable.fromPublisher(flux); // TO BE REMOVED
 	}
 
 	// TODO Adapt RxJava Flowable to Flux
 	Flux<User> fromFlowableToFlux(Flowable<User> flowable) {
-		return null;
+		return Flux.from(flowable); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Adapt Flux to RxJava Observable
 	Observable<User> fromFluxToObservable(Flux<User> flux) {
-		return null;
+		return Observable.fromPublisher(flux); // TO BE REMOVED
 	}
 
 	// TODO Adapt RxJava Observable to Flux
 	Flux<User> fromObservableToFlux(Observable<User> observable) {
-		return null;
+		return Flux.from(observable.toFlowable(BackpressureStrategy.BUFFER)); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Adapt Mono to RxJava Single
 	Single<User> fromMonoToSingle(Mono<User> mono) {
-		return null;
+		return Single.fromPublisher(mono); // TO BE REMOVED
 	}
 
 	// TODO Adapt RxJava Single to Mono
 	Mono<User> fromSingleToMono(Single<User> single) {
-		return null;
+		return Mono.from(single.toFlowable()); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Adapt Mono to Java 8+ CompletableFuture
 	CompletableFuture<User> fromMonoToCompletableFuture(Mono<User> mono) {
-		return null;
+		return mono.toFuture(); // TO BE REMOVED
 	}
 
 	// TODO Adapt Java 8+ CompletableFuture to Mono
 	Mono<User> fromCompletableFutureToMono(CompletableFuture<User> future) {
-		return null;
+		return Mono.fromFuture(future); // TO BE REMOVED
 	}
 
 }

--- a/src/main/java/io/pivotal/literx/Part10ReactiveToBlocking.java
+++ b/src/main/java/io/pivotal/literx/Part10ReactiveToBlocking.java
@@ -15,14 +15,14 @@ public class Part10ReactiveToBlocking {
 
 	// TODO Return the user contained in that Mono
 	User monoToValue(Mono<User> mono) {
-		return null;
+		return mono.block(); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Return the users contained in that Flux
 	Iterable<User> fluxToValues(Flux<User> flux) {
-		return null;
+		return flux.toIterable(); // TO BE REMOVED
 	}
 
 }

--- a/src/main/java/io/pivotal/literx/Part11BlockingToReactive.java
+++ b/src/main/java/io/pivotal/literx/Part11BlockingToReactive.java
@@ -27,14 +27,18 @@ public class Part11BlockingToReactive {
 
 	// TODO Create a Flux for reading all users from the blocking repository deferred until the flux is subscribed, and run it with an elastic scheduler
 	Flux<User> blockingRepositoryToFlux(BlockingRepository<User> repository) {
-		return null;
+		return Flux.defer(() -> Flux.fromIterable(repository.findAll()))
+		           .subscribeOn(Schedulers.elastic()); // TO BE REMOVED
 	}
 
 //========================================================================================
 
 	// TODO Insert users contained in the Flux parameter in the blocking repository using an elastic scheduler and return a Mono<Void> that signal the end of the operation
 	Mono<Void> fluxToBlockingRepository(Flux<User> flux, BlockingRepository<User> repository) {
-		return null;
+		return flux
+				.publishOn(Schedulers.elastic())
+				.doOnNext(repository::save)
+				.then(); // TO BE REMOVED
 	}
 
 }

--- a/src/test/java/io/pivotal/literx/Part03StepVerifierTest.java
+++ b/src/test/java/io/pivotal/literx/Part03StepVerifierTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/pivotal/literx/Part07ErrorsTest.java
+++ b/src/test/java/io/pivotal/literx/Part07ErrorsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/pivotal/literx/Part09AdaptTest.java
+++ b/src/test/java/io/pivotal/literx/Part09AdaptTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 6 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).