### PR TITLE
URL Cleanup

### DIFF
--- a/techio/part01Flux.md
+++ b/techio/part01Flux.md
@@ -15,7 +15,7 @@ It can emit 0 to _n_ `<T>` elements (`onNext` event) then either completes or er
 - Each `Flux#subscribe()` or multicasting operation such as `Flux#publish` and `Flux#publishNext`
   will materialize a dedicated instance of the pipeline and trigger the data flow inside it.
 
-See the javadoc [here](http://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html).
+See the javadoc [here](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html).
 
 ![Marble diagram representation of a Flux](/techio/assets/flux.png)
 

--- a/techio/part02Mono.md
+++ b/techio/part02Mono.md
@@ -17,7 +17,7 @@ materialized anew for each `Subscription`.
 Note that some API that change the sequence's cardinality will return a `Flux` (and vice-versa,
 APIs that reduce the cardinality to 1 in a `Flux` return a `Mono`).
 
-See the javadoc [here](http://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html).
+See the javadoc [here](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html).
 
 ![Marble diagram representation of a Mono](/techio/assets/mono.png)
 

--- a/techio/part03StepVerifier.md
+++ b/techio/part03StepVerifier.md
@@ -24,7 +24,7 @@ the `StepVerifier` won't subscribe to your sequence and nothing will be asserted
 StepVerifier.create(T<Publisher>).{expectations...}.verify()
 ```
 
-There are a lot of possible expectations, see the [reference documentation](http://projectreactor.io/docs/core/release/reference/docs/index.html#_testing_a_scenario_with_code_stepverifier_code)
+There are a lot of possible expectations, see the [reference documentation](https://projectreactor.io/docs/core/release/reference/docs/index.html#_testing_a_scenario_with_code_stepverifier_code)
 and the [javadoc](https://javadoc.io/page/io.projectreactor.addons/reactor-test/3.0/reactor/test/StepVerifier.Step.html). 
 
 ## Practice 

--- a/techio/part08OtherOperations.md
+++ b/techio/part08OtherOperations.md
@@ -4,9 +4,9 @@
 
 In this section, we'll have a look at a few more useful operators that don't fall into
 the broad categories we explored earlier. Reactor 3 contains a _lot_ of operators, so don't
-hesitate to have a look at the [Flux](http://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html)
-and [Mono](http://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html)
-javadocs as well as the [reference guide](http://projectreactor.io/docs/core/release/reference/docs/index.html#which-operator)
+hesitate to have a look at the [Flux](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html)
+and [Mono](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html)
+javadocs as well as the [reference guide](https://projectreactor.io/docs/core/release/reference/docs/index.html#which-operator)
 to learn about more of them.
 
 ## Practice


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html with 2 occurrences migrated to:  
  https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html ([https](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html) result 200).
* [ ] http://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html with 2 occurrences migrated to:  
  https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html ([https](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html) result 200).
* [ ] http://projectreactor.io/docs/core/release/reference/docs/index.html with 2 occurrences migrated to:  
  https://projectreactor.io/docs/core/release/reference/docs/index.html ([https](https://projectreactor.io/docs/core/release/reference/docs/index.html) result 302).