### PR TITLE
fix #52 Improve noSignal test, bump to core 3.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
 			<dependency>
 				<groupId>io.projectreactor</groupId>
 				<artifactId>reactor-bom</artifactId>
-				<version>Bismuth-SR11</version>
+				<version>Dysprosium-SR2</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/src/test/java/io/pivotal/literx/Part02MonoTest.java
+++ b/src/test/java/io/pivotal/literx/Part02MonoTest.java
@@ -33,8 +33,7 @@ public class Part02MonoTest {
 		StepVerifier
 				.create(mono)
 				.expectSubscription()
-				.expectNoEvent(Duration.ofSeconds(1))
-				.thenCancel()
+				.expectTimeout(Duration.ofSeconds(1))
 				.verify();
 	}
 


### PR DESCRIPTION
This fixes #52 by using the new `expectTimeout` step verifier introduced in a recent version of _reactor-core_. See https://github.com/reactor/reactor-core/issues/1913 and https://github.com/reactor/reactor-core/pull/1931 for more information about this change.