### PR TITLE
Fix wrongly ordered assertThat#withFailMessage not showing

### DIFF
--- a/src/test/java/io/pivotal/literx/Part11BlockingToReactiveTest.java
+++ b/src/test/java/io/pivotal/literx/Part11BlockingToReactiveTest.java
@@ -38,7 +38,9 @@ public class Part11BlockingToReactiveTest {
 	public void slowPublisherFastSubscriber() {
 		BlockingUserRepository repository = new BlockingUserRepository();
 		Flux<User> flux = workshop.blockingRepositoryToFlux(repository);
-		assertThat(repository.getCallCount()).isEqualTo(0).withFailMessage("The call to findAll must be deferred until the flux is subscribed");
+		assertThat(repository.getCallCount())
+				.withFailMessage("The call to findAll must be deferred until the flux is subscribed")
+				.isEqualTo(0);
 		StepVerifier.create(flux)
 				.expectNext(User.SKYLER, User.JESSE, User.WALTER, User.SAUL)
 				.verifyComplete();


### PR DESCRIPTION
Hi,
in Part11BlockingToReactiveTest.slowPublisherFastSubscriber method: withFailMessage is ignored and no fail message will be show. 
`assertThat(repository.getCallCount()).isEqualTo(0).withFailMessage("The call to findAll must be deferred until the flux is subscribed");`
To test that modify Part11BlockingToReactive.blockingRepositoryToFlux mothod as following:
`return Flux.fromIterable(repository.findAll());`
the test will failed but fail message is not displayed.
after small change, it is fixed:
`assertThat(repository.getCallCount())
				.withFailMessage("The call to findAll must be deferred until the flux is subscribed")
				.isEqualTo(0);`
now the fail message is displayed if the assert is false.
hope my request is useful.
Thanks.