### PR TITLE
Now v1.3.0: Update to Reactor 2020.0.x, bump other dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,11 +20,11 @@
 
 	<groupId>io.pivotal</groupId>
 	<artifactId>lite-rx-api-hands-on</artifactId>
-	<version>1.2.0-SNAPSHOT</version>
+	<version>1.3.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>A lite Rx API for the JVM Hands-on</name>
-	<description>Lite Rx API Hands-On based on Reactor Core 3.3.4</description>
+	<description>Lite Rx API Hands-On based on Reactor Core 3.x</description>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -37,29 +37,35 @@
 			<artifactId>reactor-core</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<version>3.0.1</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-test</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.2.0</version>
+			<version>1.2.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>5.6.1</version>
+			<version>5.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.reactivex.rxjava3</groupId>
 			<artifactId>rxjava</artifactId>
-			<version>3.0.1</version>
+			<version>3.1.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
-			<version>3.15.0</version>
+			<version>3.22.0</version>
 		</dependency>
 	</dependencies>
 
@@ -92,7 +98,7 @@
 			<dependency>
 				<groupId>io.projectreactor</groupId>
 				<artifactId>reactor-bom</artifactId>
-				<version>Dysprosium-SR6</version>
+				<version>2020.0.16</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/src/main/java/io/pivotal/literx/Part11BlockingToReactive.java
+++ b/src/main/java/io/pivotal/literx/Part11BlockingToReactive.java
@@ -25,14 +25,14 @@ public class Part11BlockingToReactive {
 
 //========================================================================================
 
-	// TODO Create a Flux for reading all users from the blocking repository deferred until the flux is subscribed, and run it with an elastic scheduler
+	// TODO Create a Flux for reading all users from the blocking repository deferred until the flux is subscribed, and run it with a bounded elastic scheduler
 	Flux<User> blockingRepositoryToFlux(BlockingRepository<User> repository) {
 		return null;
 	}
 
 //========================================================================================
 
-	// TODO Insert users contained in the Flux parameter in the blocking repository using an elastic scheduler and return a Mono<Void> that signal the end of the operation
+	// TODO Insert users contained in the Flux parameter in the blocking repository using a bounded elastic scheduler and return a Mono<Void> that signal the end of the operation
 	Mono<Void> fluxToBlockingRepository(Flux<User> flux, BlockingRepository<User> repository) {
 		return null;
 	}


### PR DESCRIPTION
As a follow-up to this PR:

 - [x] the `solution` branch will need to be updated to replace deprecated APIs
 - [x] the `tech_io` branch will need to be updated to reflect new APIs and the
 new version 1.3.0-SNAPSHOT
 - [x] the workshop will need to be redeployed on tech.io﻿