### PR TITLE
Part 06 should avoid doOnSubscribe, prefer doFirst

### DIFF
--- a/src/main/java/io/pivotal/literx/Part06Request.java
+++ b/src/main/java/io/pivotal/literx/Part06Request.java
@@ -38,7 +38,7 @@ public class Part06Request {
 
 //========================================================================================
 
-	// TODO Return a Flux with all users stored in the repository that prints "Starring:" on subscribe, "firstname lastname" for all values and "The end!" on complete
+	// TODO Return a Flux with all users stored in the repository that prints "Starring:" at first, "firstname lastname" for all values and "The end!" on complete
 	Flux<User> fluxWithDoOnPrintln() {
 		return null;
 	}


### PR DESCRIPTION
TODO after this PR is merged:

 - [x] `solution` should use `doFirst` in Part06
 - [x] `techio_course` should mention `doFirst` rather than `doOnSubscribe` in
 part06.md﻿