### PR TITLE
Upgrade to Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.version>1.8</java.version>
+		<java.version>11</java.version>
 	</properties>
 
 	<dependencies>
@@ -76,8 +76,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.6.1</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
This commit upgrades the Java version in the project to version 11.

Java 8 has been EoL (End of Life) for some time so it make sense to upgrade to a later version. It can be debated whether or not one should upgrade to Java 11 which is the next Java LTS (Long Term Support) version after Java 8 and (released in September 2018) or if one should upgrade to Java 17 which is the current LTS version (released in September 2021). Either one is a step in the right direction.

ref: https://www.oracle.com/java/technologies/java-se-support-roadmap.html