### PR TITLE
Fix Part06 test, use User{} instead of Person{}

### DIFF
--- a/src/test/java/io/pivotal/literx/Part06RequestTest.java
+++ b/src/test/java/io/pivotal/literx/Part06RequestTest.java
@@ -86,12 +86,12 @@ public class Part06RequestTest {
 		assertThat(log)
 				.containsExactly("onSubscribe(FluxZip.ZipCoordinator)"
 						, "request(1)"
-						, "onNext(Person{username='swhite', firstname='Skyler', lastname='White'})"
+						, "onNext(User{username='swhite', firstname='Skyler', lastname='White'})"
 						, "request(1)"
-						, "onNext(Person{username='jpinkman', firstname='Jesse', lastname='Pinkman'})"
+						, "onNext(User{username='jpinkman', firstname='Jesse', lastname='Pinkman'})"
 						, "request(2)"
-						, "onNext(Person{username='wwhite', firstname='Walter', lastname='White'})"
-						, "onNext(Person{username='sgoodman', firstname='Saul', lastname='Goodman'})"
+						, "onNext(User{username='wwhite', firstname='Walter', lastname='White'})"
+						, "onNext(User{username='sgoodman', firstname='Saul', lastname='Goodman'})"
 						, "onComplete()");
 	}
 


### PR DESCRIPTION
Fix broken part 06 test, due to recent commit in [d682178](https://github.com/reactor/lite-rx-api-hands-on/commit/d6821782b5328735466cd79ee015f71415bd04f7)